### PR TITLE
Add rainbow fractal in p5.js

### DIFF
--- a/challenges/CC_61_fractal_spirograph/README.md
+++ b/challenges/CC_61_fractal_spirograph/README.md
@@ -1,3 +1,4 @@
 # Community Variations
 
 * [JosefKuchar's changes to render large images](https://github.com/JosefKuchar/p5-projects/tree/master/CC_61_fractal_spirograph_large_render) - [Demo](https://josefkuchar.github.io/p5-projects/CC_61_fractal_spirograph_large_render/)
+* [Zalastax rainbow fractal in p5.js](https://github.com/Zalastax/p5js-projects/tree/master/CC_61_fractal_spirograph_rainbow) - [Demo](https://zalastax.github.io/p5js-projects/CC_61_fractal_spirograph_rainbow/)


### PR DESCRIPTION
I'm not completely happy with https://github.com/Zalastax/p5js-projects/blob/master/CC_61_fractal_spirograph_rainbow/sketch.js#L51-L52 though, because of how bad the performance gets. Any way of creating performant gradient line shapes in p5.js?