### PR TITLE
Bug: selfAngle not initialised for first segment.

### DIFF
--- a/challenges/CC_64_1_a_ForwardKinematics/Segment.pde
+++ b/challenges/CC_64_1_a_ForwardKinematics/Segment.pde
@@ -26,6 +26,7 @@ class Segment {
     a = new PVector(x, y);
     len = len_;
     angle = angle_;
+    selfAngle = angle;
     calculateB();
     parent = null;
     t = t_;


### PR DESCRIPTION
Since the selfAngle variable is not initialised for the segment with no parent, the animations always begin from angle = 0. If we look at the animation around 1:25:40 in the live stream video, the segments begin to rotate from angle = 0, even though the first segment is defined to start from angle = -45.