### PR TITLE
Declare boxes array within setup to fix array filling error

### DIFF
--- a/Tutorials/P5JS/p5.js_video/10.5_checkbox_mirror/sketch.js
+++ b/Tutorials/P5JS/p5.js_video/10.5_checkbox_mirror/sketch.js
@@ -6,11 +6,12 @@ var slider;
 var cols = 40;
 var rows = 30;
 
-var boxes = [];
+var boxes;
 
 function setup() {
   noCanvas();
   pixelDensity(1);
+  boxes = [];
   video = createCapture(VIDEO);
   video.size(cols, rows);
   slider = createSlider(0, 255, 77);

--- a/Tutorials/P5JS/p5.js_video/10.5_checkbox_mirror/sketch.js
+++ b/Tutorials/P5JS/p5.js_video/10.5_checkbox_mirror/sketch.js
@@ -6,7 +6,7 @@ var slider;
 var cols = 40;
 var rows = 30;
 
-const boxes = [];
+var boxes = [];
 
 function setup() {
   noCanvas();

--- a/Tutorials/P5JS/p5.js_video/10.5_checkbox_mirror/sketch.js
+++ b/Tutorials/P5JS/p5.js_video/10.5_checkbox_mirror/sketch.js
@@ -6,7 +6,7 @@ var slider;
 var cols = 40;
 var rows = 30;
 
-var boxes = [];
+const boxes = [];
 
 function setup() {
   noCanvas();


### PR DESCRIPTION
It seems there’s an issue in Firefox if the `boxes` array is not
declared within setup. As a result when looping through draw, something goes wonky with the
`boxes` variable and we get `boxes[checkIndex] is
undefined` error. I hope this helps! Thanks for all the great work and materials 🌈❤️!