### PR TITLE
Fix simetry (updated)

### DIFF
--- a/CodingChallenges/CC_60_Butterfly_Wings/sketch.js
+++ b/CodingChallenges/CC_60_Butterfly_Wings/sketch.js
@@ -12,7 +12,7 @@ function setup() {
 function draw() {
   background(51);
   translate(width / 2, height / 2);
-  rotate(PI / 2);
+  //rotate(PI / 2);
 
   stroke(255);
   fill(255, 50);
@@ -28,7 +28,7 @@ function draw() {
     var r = sin(2 * a) * map(n, 0, 1, 50, 300);
     var x = r * cos(a);
     var y = r * sin(a);
-    if (a < PI / 2){
+    if (a < PI){
         xoff += dx; 
     } else{
         xoff -= dx; 


### PR DESCRIPTION
(Sorry, my previous pull request somehow included my own customisations, in addition to the fix. I hope it's fine now)

The condition on line 31 was producing 3 equal wings and one different, instead of two and two. Once that's changed, the rotation is not necessary, it produced simetry on the horizontal axis instead of the vertical one.