### PR TITLE
🐛  Menu links don't hide on mobile

### DIFF
--- a/_jekyll/includes/2-base/header.html
+++ b/_jekyll/includes/2-base/header.html
@@ -14,5 +14,4 @@
       <a href="{{ '/Courses' | relative_url }}">Courses</a>
     </div>
   </nav>
-  <!-- <img src="{{ '/assets/images/header.jpg' | relative_url }}"> -->
 </header>

--- a/assets/css/2-base/_header.sass
+++ b/assets/css/2-base/_header.sass
@@ -13,6 +13,7 @@ header
     height: 50px
     font-size: 16px
     background: $ct-blue
+    overflow: hidden
 
     transition: all 200ms
 

--- a/assets/css/2-base/_header.sass
+++ b/assets/css/2-base/_header.sass
@@ -48,5 +48,3 @@ header
         @media (max-width: $mobile)
           margin: 0.5em 0
 
-  img
-    width: 100%


### PR DESCRIPTION
Closes issue #370

This should now be fixed. I somehow forgot to set `overflow: hidden` for the `nav` container.
Therefore, the links were "peaking out" since their `height` property was set to `auto` (used for animating the menu in).

Big thanks to @Maik1999 for pointing me in the right direction!