### PR TITLE
Added google analytics gtag.js script to the header

### DIFF
--- a/_jekyll/includes/2-base/head.html
+++ b/_jekyll/includes/2-base/head.html
@@ -3,6 +3,22 @@
 {% endcomment %}
 
 
+{% comment %}
+  Global site tag (gtag.js) - Google Analytics
+  This will only be included in production mode so local testing doesn't affect
+  the tracking result.
+{% endcomment %}
+{% if jekyll.environment == 'production' %}
+  <script async src="https://www.googletagmanager.com/gtag/js?id=UA-112820770-1"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+      
+    gtag('config', 'UA-112820770-1');
+  </script>
+{% endif %}
+
 <title>{{ site.title }}</title>
 
 <meta charset="utf-8">


### PR DESCRIPTION
This script will only be visible when the site was built in production mode to not influence the tracking results when testing locally.

Closes #399 